### PR TITLE
docs: add README and update CLAUDE.md for CI-based PDF build

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -10,6 +10,7 @@
     "CI",
     "Deedy",
     "ES",
+    "ifseniormgr",
     "ISTAR",
     "LDWS",
     "MOSFET",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ There are two entry points, representing tailored CV variants:
 
 Both are thin wrappers: they carry the (identical) preamble, declare `\newif\ifseniormgr`, set the flag, and `\input{body}`. **All shared content lives in `body.tex`** — a single source of truth. The two variants no longer drift: edit `body.tex` once, and wrap any variant-specific difference in `\ifseniormgr … \else … \fi`. Keep the preamble in the two wrappers identical to each other. (Build either wrapper with XeLaTeX; they select their variant via the flag.)
 
+The canonical compiled PDFs are now produced automatically via GitHub Actions CI (`.github/workflows/build-pdf.yml`) on every push to `main` and published to the rolling `latest` GitHub Release. Overleaf remains available for optional WYSIWYG spacing and layout tweaks, but is no longer required to obtain a compiled PDF.
+
 ## Architecture
 
 - **`deedy-resume-openfont-wjl.cls`** — the custom document class. Defines all colours, fonts (Lato / Raleway / Source Sans Pro, vendored under `fonts/`), and the semantic commands used throughout the content files:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# William Lay's CV
+
+A single-page LaTeX CV/résumé, based on a modified one-column version of the Deedy-Resume template. Built with XeLaTeX.
+
+## Build Status
+
+![Build PDF](https://github.com/laywill/CV/actions/workflows/build-pdf.yml/badge.svg)
+
+## Compiled PDFs
+
+The latest compiled PDFs are available at [github.com/laywill/CV/releases/latest](https://github.com/laywill/CV/releases/latest):
+- `main.pdf` — general CV variant
+- `main_senior_engineering_manager.pdf` — senior engineering manager-tailored variant
+
+These are automatically generated on every push to `main` via CI.
+
+## Variants
+
+This repository maintains two CV variants:
+- **`main.tex`** — the general CV variant
+- **`main_senior_engineering_manager.tex`** — tailored for a senior engineering manager role
+
+Both variants share the same content in `body.tex`, with variant-specific sections toggled via the `\ifseniormgr` conditional. See `CLAUDE.md` for full architecture and build details.


### PR DESCRIPTION
## Summary

This PR implements issue #40 by adding documentation for the new CI-based PDF build workflow:

- **Add README.md** with build status badge for the `build-pdf.yml` workflow and links to the latest compiled PDFs
- **Update CLAUDE.md** to document that CI now produces canonical PDFs automatically on every push to `main`
- Note that Overleaf remains available for optional WYSIWYG tweaks but is no longer required

Closes #40

## Test Plan

- [x] README.md created with build badge and release link
- [x] CLAUDE.md updated with concise CI documentation
- [x] Changes follow British spelling conventions (cspell en-GB)
- [x] No LaTeX files modified (documentation only)

🤖 Generated with Claude Code