### PR TITLE
ci: add sticky PR comment with build artifacts link

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -51,3 +51,25 @@ jobs:
           name: cv-${{ matrix.entrypoint }}
           path: ${{ matrix.entrypoint }}.pdf
           retention-days: 30
+
+  comment-on-pr:
+    name: Comment on PR with artifact links
+    runs-on: ubuntu-latest
+    needs: build-pdf
+    if: github.event_name == 'pull_request'
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Comment on PR with workflow run link
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: build-pdf-artifacts
+          message: |
+            ## PDF Build Complete
+
+            Compiled PDFs are available to download from the [workflow run artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+            - `cv-main.pdf`
+            - `cv-main_senior_engineering_manager.pdf`


### PR DESCRIPTION
## Summary

Extends `.github/workflows/build-pdf.yml` to post a sticky comment on pull requests that links to the workflow run where compiled PDF artifacts can be downloaded.

- Uses `marocchino/sticky-pull-request-comment` (v3.0.5, pinned to commit SHA) to post the comment
- Updates the existing comment on subsequent pushes to the same PR rather than creating duplicates
- Adds a new `comment-on-pr` job that runs only on `pull_request` events and depends on the `build-pdf` job
- Follows repo conventions: actions pinned to commit SHAs, minimal permissions (`pull-requests: write` only for this job)

Closes #42