### PR TITLE
Tooling: adopt repo-hygiene config from github-template

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -11,6 +11,7 @@
     "COTS",
     "Claude",
     "Copilot",
+    "danteev",
     "Deedy",
     "ES",
     "ISTAR",
@@ -28,10 +29,12 @@
     "Telethon",
     "telethons",
     "subagents",
+    "texlive",
     "Ubiquiti",
     "Unifi",
     "Vivado",
-    "Xilinx"
+    "Xilinx",
+    "Zsh"
   ],
   "ignoreWords": [
     "chktex",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "CV",
+  "image": "danteev/texlive:latest",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "configureZshAsDefaultShell": true,
+      "installOhMyZsh": true,
+      "upgradePackages": true,
+      "username": "vscode",
+      "userUid": "automatic",
+      "userGid": "automatic"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "editorconfig.editorconfig",
+        "streetsidesoftware.code-spell-checker",
+        "James-Yu.latex-workshop"
+      ]
+    }
+  },
+  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.rst]
+trim_trailing_whitespace = false
+
+[*.tex]
+trim_trailing_whitespace = false
+
+[*.py]
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[*.{bat,cmd}]
+end_of_line = crlf

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,9 @@
 # Default owner for the CV repository
 
 * @laywill
+
+# GitHub Actions workflows
+.github/workflows/* @laywill
+
+# Devcontainer configuration
+.devcontainer/* @laywill

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    labels:
+      - "github_actions"
+      - "chore"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,27 @@
+---
+# Declarative label set, synced into the repo by
+# .github/workflows/labels.yml. "Use this template" only copies files, not
+# labels, so this is what makes labels actually show up here.
+#
+# Curated for a solo CV content repo rather than a collaborative software
+# project - no bug/enhancement/good-first-issue style labels.
+
+- name: content
+  color: "0e8a16"
+  description: CV wording, positioning, or entry changes
+
+- name: tooling
+  color: "1d76db"
+  description: CI, build, lint, or devcontainer changes
+
+- name: nit
+  color: "cfd3d7"
+  description: Small polish or cleanup, no functional change
+
+- name: github_actions
+  color: "000000"
+  description: GitHub Actions workflow/dependency updates
+
+- name: chore
+  color: "ededed"
+  description: Maintenance work that isn't content or tooling

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,57 @@
+---
+name: CodeQL
+
+# Trigger CodeQL analysis on pushes/PRs to main and on a weekly schedule so
+# alerts surface even without recent code changes.
+on: # yamllint disable-line rule:truthy - false positive
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "17 3 * * 1"
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # This repo has no application code, just GitHub Actions workflow
+        # YAML - scan that. See
+        # https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#changing-the-languages-that-are-analyzed
+        # for the full list of supported identifiers.
+        language:
+          - actions
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e60ea984bd3baa95954f2856bcf24f9eaba46637  # v3.37.5
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@e60ea984bd3baa95954f2856bcf24f9eaba46637  # v3.37.5
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e60ea984bd3baa95954f2856bcf24f9eaba46637  # v3.37.5
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ on: # yamllint disable-line rule:truthy - false positive
     branches:
       - main
   schedule:
+    # Runs weekly, Monday at 03:17 UTC
     - cron: "17 3 * * 1"
 
 concurrency:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,35 @@
+---
+name: Labels
+
+# Sync repository labels from .github/labels.yml.
+on: # yamllint disable-line rule:truthy - false positive
+  push:
+    branches:
+      - main
+    paths:
+      - .github/labels.yml
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  labeler:
+    name: Sync labels
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Sync labels
+        uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d  # v6.0.0
+        with:
+          yaml-file: .github/labels.yml
+          skip-delete: false

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -16,3 +16,9 @@ EMAIL_REPORTER: false
 SPELL_FILTER_REGEX_EXCLUDE: (fonts|\.github|\.mega-linter.yml|\.gitattributes|\.gitignore|CLAUDE.md|\.vscode)
 MARKDOWN_FILTER_REGEX_EXCLUDE: (CLAUDE.md)
 LATEX_CHKTEX_ARGUMENTS: --nowarn 13
+
+# EditorConfig Checker Config
+# Exclude LICENSE.txt: it is the canonical Apache License 2.0 text copied
+# verbatim from apache.org and should not be reformatted to satisfy
+# indent-size/trailing-whitespace rules.
+EDITORCONFIG_EDITORCONFIG_CHECKER_FILTER_REGEX_EXCLUDE: (LICENSE)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: mixed-line-ending

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "streetsidesoftware.code-spell-checker",
+    "James-Yu.latex-workshop"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "editor.rulers": [80, 100, 120],
+  "editor.detectIndentation": true,
+  "editor.formatOnSave": false,
+  "[markdown]": {
+    "files.trimTrailingWhitespace": false
+  },
+  "[latex]": {
+    "files.trimTrailingWhitespace": false
+  },
+  "[restructuredtext]": {
+    "files.trimTrailingWhitespace": false
+  }
+}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,9 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: warning
+  truthy:
+    check-keys: false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If a vulnerability is suitable for immediate public disclosure (low
+severity, no active exploit risk), please open a
+[GitHub issue](../../issues/new/choose).
+
+Otherwise, if it needs to stay private until fixed, contact William Lay
+([@laywill](https://github.com/laywill) on GitHub) directly rather than
+opening a public issue or pull request.
+
+Please include as much detail as possible: affected file(s)/workflow(s),
+steps to reproduce, and potential impact.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 If a vulnerability is suitable for immediate public disclosure (low
 severity, no active exploit risk), please open a
-[GitHub issue](../../issues/new/choose).
+[GitHub issue](https://github.com/laywill/CV/issues/new/choose).
 
 Otherwise, if it needs to stay private until fixed, contact William Lay
 ([@laywill](https://github.com/laywill) on GitHub) directly rather than


### PR DESCRIPTION
## Summary

- Backports editor/lint tooling, a LaTeX devcontainer, and select GitHub repo-hygiene config from [laywill/github-template](https://github.com/laywill/github-template)
- Curated to fit a solo CV content repo rather than a collaborative OSS project — see the PR diff for what was deliberately left out (CONTRIBUTING.md, CODE_OF_CONDUCT.md, PR/issue templates, `.github/release.yml`, the full bug/enhancement label set)

Closes #49

## Changes (7 commits, one per concern)

1. `.editorconfig`, `.pre-commit-config.yaml`, `.yamllint.yml`
2. `.vscode/settings.json` + `.vscode/extensions.json`
3. `.devcontainer/devcontainer.json` — LaTeX-flavoured (`danteev/texlive`), not the template's generic Ubuntu base
4. `.github/workflows/codeql.yml` — scans GitHub Actions workflow YAML (no application code here)
5. `SECURITY.md`
6. `.github/labels.yml` + labels-sync workflow — curated label set (`content`, `tooling`, `nit`, `github_actions`, `chore`)
7. `.github/dependabot.yml` grouping/labels + expanded `.github/CODEOWNERS`

## ⚠️ Note before merging

The labels-sync workflow (commit 6) runs with `skip-delete: false`. Its first run on `main` will delete any existing repo labels not in the curated 5 — worth checking [Issues → Labels](https://github.com/laywill/CV/labels) before merging. The `tooling` label was already created manually to file the linked issue; the sync workflow will just re-affirm it.

## Test plan

- [x] `.editorconfig`, `.pre-commit-config.yaml`, `.yamllint.yml`, `.devcontainer/devcontainer.json`, `SECURITY.md` all pass `cspell` locally with 0 issues
- [x] All new/edited YAML and JSON parse cleanly; `yamllint` passes with only pre-existing-style warnings (no errors)
- [x] Confirmed `danteev/texlive:latest` exists on Docker Hub
- [ ] Let MegaLinter CI run on this PR and confirm it's clean
- [ ] Let `build-pdf.yml` run and confirm the XeLaTeX build is unaffected
- [ ] Build the devcontainer (VS Code "Reopen in Container") and confirm `latexmk -xelatex main.tex` works from repo root