### PR TITLE
CI: switch MegaLinter to the github-latex-markdown custom flavor

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -63,9 +63,11 @@ jobs:
       # MegaLinter
       - name: MegaLinter
 
-        # You can override MegaLinter flavor used to have faster performances
-        # More info at https://megalinter.io/latest/flavors/
-        uses: oxsecurity/megalinter@15e5b45552097e318c93de385779ce3b1084052c # v10.0.0
+        # Custom flavor pre-scoped to the linters this repo actually uses
+        # (GitHub Actions, LaTeX, Markdown, YAML/JSON, spelling, secrets/SBOM
+        # scanning) rather than the full generic MegaLinter image.
+        # More info at https://github.com/laywill/megalinter-custom-flavor-github-latex-markdown
+        uses: laywill/megalinter-custom-flavor-github-latex-markdown@13ebde04a17b79972fb4f1b2417851230306dc37 # v10.0.0
 
         id: ml
 

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -4,14 +4,6 @@
 
 FILTER_REGEX_EXCLUDE: '(fonts)'
 APPLY_FIXES: all
-DISABLE:
-  - COPYPASTE # Uncomment to disable checks of excessive copy-pastes
-DISABLE_LINTERS:
-  - JSON_PRETTIER
-  - YAML_PRETTIER
-  - COPYPASTE_JSCPD
-  - REPOSITORY_CHECKOV
-  - ACTION_ZIZMOR
 EMAIL_REPORTER: false
 SPELL_FILTER_REGEX_EXCLUDE: (fonts|\.github|\.mega-linter.yml|\.gitattributes|\.gitignore|CLAUDE.md|\.vscode)
 MARKDOWN_FILTER_REGEX_EXCLUDE: (CLAUDE.md)


### PR DESCRIPTION
Closes #58

## Changes
- `mega-linter.yml`: replace `oxsecurity/megalinter` with `laywill/megalinter-custom-flavor-github-latex-markdown`, pinned to the `v10.0.0` release SHA (matching the previous MegaLinter version already in use).
- `.mega-linter.yml`: drop the `DISABLE`/`DISABLE_LINTERS` entries (`COPYPASTE`, `JSON_PRETTIER`, `YAML_PRETTIER`, `COPYPASTE_JSCPD`, `REPOSITORY_CHECKOV`, `ACTION_ZIZMOR`) — none of these linters are included in the custom flavor, so disabling them was dead config.

cspell (en-GB), chktex (`--nowarn 13`), and the `fonts/` exclusion settings are untouched, so should behave the same. Let CI on this PR confirm the flavor swap actually lints correctly and the auto-fix-commit path still works on a non-`main` branch.

## Test plan
- [ ] CI run on this PR passes with the new flavor
- [ ] Auto-commit-back-fixes behaviour still triggers correctly on this branch if any fixable issues are found